### PR TITLE
Update widget for all sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A fully customizable [Scriptable](https://scriptable.app) widget for iOS that di
 - 🌍 Multi-language support: English, German, French, Spanish
 - 📅 Two optional change columns (e.g. 1-day, 7-day change)
 - 🌗 Full support for dark and light mode
-- 📱 Optimized for **medium** and **large** Scriptable widgets
+- 📱 Optimized for **all widget sizes**, including lock screen widgets
 - ⚙️ Simple and clean configuration at the top of the script
 
 ## 🛠 Configuration
@@ -38,6 +38,8 @@ const SYMBOLS = [
   { symbol: "MSFT",      label: "Microsoft" }
 ]
 ```
+
+Small and lock screen widgets will only display the first asset in the list.
 
 ## 🖼️ Example Images
 

--- a/finance_widget.js
+++ b/finance_widget.js
@@ -85,7 +85,8 @@ function getColor(val, gray) {
 // Define fixed layout width (medium and large share same width)
 function getAdjustedWidgetWidth() {
   switch (config.widgetFamily) {
-    case "small": return 0
+    case "small":
+      return 150
     case "medium":
     case "large":
     default:
@@ -114,21 +115,26 @@ async function createWidget() {
   title.textColor = TEXT
   title.font = Font.boldSystemFont(14)
   widget.addSpacer(8)
-  // Show message if widget is too small
-  if (config.widgetFamily === "small") {
-    const msgStack = widget.addStack()
-    msgStack.addSpacer()
-    const msg = msgStack.addText("Please use at least\na medium-sized widget.")
-    msg.font = Font.systemFont(12)
-    msg.textColor = GRAY
-    msg.centerAlignText()
-    msgStack.addSpacer()
-    widget.addSpacer()
-    const now = new Date()
-    const time = widget.addText(now.toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" }))
-    time.font = Font.systemFont(10)
-    time.textColor = GRAY
-    time.leftAlignText()
+  // Handle small and lock-screen widgets with a simplified layout
+  const isAccessory = config.widgetFamily?.startsWith("accessory")
+  if (config.widgetFamily === "small" || isAccessory) {
+    const asset = SYMBOLS[0]
+    const data = await fetchSymbolData(asset.symbol)
+    if (data) {
+      const label = widget.addText(asset.label)
+      label.textColor = TEXT
+      label.font = Font.boldSystemFont(isAccessory ? 12 : 14)
+      widget.addSpacer(2)
+      const price = widget.addText(`${data.price.toFixed(2)} ${data.currency}`)
+      price.textColor = TEXT
+      price.font = Font.systemFont(isAccessory ? 10 : 12)
+      if (ENABLE_CHANGE_COL_1 && data.change1 !== null) {
+        widget.addSpacer(1)
+        const c1 = widget.addText(formatChange(data.change1))
+        c1.textColor = getColor(data.change1, GRAY)
+        c1.font = Font.systemFont(isAccessory ? 9 : 11)
+      }
+    }
     return widget
   }
   // Fetch and prepare price data


### PR DESCRIPTION
## Summary
- support lock-screen and small widget sizes in `finance_widget.js`
- update README to mention full widget size support and usage notes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852079e0638832f9324ae4551d90a7f